### PR TITLE
Return event from peek

### DIFF
--- a/termbox.c
+++ b/termbox.c
@@ -418,8 +418,6 @@ PHP_FUNCTION(termbox_peek_event)
 
     array_init(return_value);
     _termbox_event_to_php_array(&event, return_value);
-
-    RETURN_LONG(rc);
 }
 /* }}} */
 


### PR DESCRIPTION
Previously we were returning the response code from the underlying library call. This change means we now return the event data so we can see what event, if any, was triggered.
